### PR TITLE
feat: add domain ID support for proof submission

### DIFF
--- a/src/api/extrinsic/index.test.ts
+++ b/src/api/extrinsic/index.test.ts
@@ -54,7 +54,42 @@ describe('extrinsic utilities', () => {
         proofParams.formattedVk,
         proofParams.formattedProof,
         proofParams.formattedPubs,
-        null, // TODO: Aggregate pallet (domain_id)
+        null,
+      );
+      expect(extrinsic.toHex()).toBe('0x1234');
+    });
+
+    it('should create a submittable extrinsic with a specific domainId', () => {
+      const domainId = 42;
+      const extrinsic = createSubmitProofExtrinsic(
+        mockApi,
+        ProofType.groth16,
+        proofParams,
+        domainId,
+      );
+
+      expect(mockTxMethod.submitProof).toHaveBeenCalledWith(
+        proofParams.formattedVk,
+        proofParams.formattedProof,
+        proofParams.formattedPubs,
+        domainId,
+      );
+      expect(extrinsic.toHex()).toBe('0x1234');
+    });
+
+    it('should handle undefined domainId as null', () => {
+      const extrinsic = createSubmitProofExtrinsic(
+        mockApi,
+        ProofType.groth16,
+        proofParams,
+        undefined,
+      );
+
+      expect(mockTxMethod.submitProof).toHaveBeenCalledWith(
+        proofParams.formattedVk,
+        proofParams.formattedProof,
+        proofParams.formattedPubs,
+        null,
       );
       expect(extrinsic.toHex()).toBe('0x1234');
     });
@@ -98,7 +133,42 @@ describe('extrinsic utilities', () => {
         proofParams.formattedVk,
         proofParams.formattedProof,
         proofParams.formattedPubs,
-        null, // TODO: Aggregate pallet (domain_id)
+        null,
+      );
+      expect(hex).toBe('0x1234');
+    });
+
+    it('should return hex representation with specific domainId', () => {
+      const domainId = 42;
+      const hex = createExtrinsicHex(
+        mockApi,
+        ProofType.groth16,
+        proofParams,
+        domainId,
+      );
+
+      expect(mockTxMethod.submitProof).toHaveBeenCalledWith(
+        proofParams.formattedVk,
+        proofParams.formattedProof,
+        proofParams.formattedPubs,
+        domainId,
+      );
+      expect(hex).toBe('0x1234');
+    });
+
+    it('should handle undefined domainId as null in hex generation', () => {
+      const hex = createExtrinsicHex(
+        mockApi,
+        ProofType.groth16,
+        proofParams,
+        undefined,
+      );
+
+      expect(mockTxMethod.submitProof).toHaveBeenCalledWith(
+        proofParams.formattedVk,
+        proofParams.formattedProof,
+        proofParams.formattedPubs,
+        null,
       );
       expect(hex).toBe('0x1234');
     });

--- a/src/api/extrinsic/index.ts
+++ b/src/api/extrinsic/index.ts
@@ -11,6 +11,7 @@ import { FormattedProofData } from '../format/types';
  * @param {ApiPromise} api - The Polkadot API instance.
  * @param {ProofType} proofType - The type of supported proof, used to select the correct pallet.
  * @param {FormattedProofData} params - Formatted Proof Parameters required by the extrinsic.
+ * @param {number | null | undefined} domainId - The domain ID for the extrinsic (32-bit unsigned integer).
  * @returns {SubmittableExtrinsic<'promise'>} The generated SubmittableExtrinsic for submission.
  * @throws {Error} - Throws an error if the extrinsic creation fails.
  */
@@ -18,6 +19,7 @@ export const createSubmitProofExtrinsic = (
   api: ApiPromise,
   proofType: ProofType,
   params: FormattedProofData,
+  domainId: number | null = null,
 ): SubmittableExtrinsic<'promise'> => {
   const pallet = getProofPallet(proofType);
 
@@ -30,7 +32,7 @@ export const createSubmitProofExtrinsic = (
       params.formattedVk,
       params.formattedProof,
       params.formattedPubs,
-      null, // TODO: Update with aggregate pallet functionality (domain_id)
+      domainId,
     );
   } catch (error: unknown) {
     throw new Error(formatError(error, proofType, params));
@@ -43,6 +45,7 @@ export const createSubmitProofExtrinsic = (
  * @param {ApiPromise} api - The Polkadot API instance.
  * @param {ProofType} proofType - The type of supported proof, used to select the correct pallet.
  * @param {FormattedProofData} params - Formatted Proof Parameters required by the extrinsic.
+ * @param {number | null | undefined} domainId - The domain ID for the extrinsic (32-bit unsigned integer).
  * @returns {string} Hex-encoded string of the SubmittableExtrinsic.
  * @throws {Error} - Throws an error if the extrinsic creation fails.
  */
@@ -50,8 +53,14 @@ export const createExtrinsicHex = (
   api: ApiPromise,
   proofType: ProofType,
   params: FormattedProofData,
+  domainId?: number | null,
 ): string => {
-  const extrinsic = createSubmitProofExtrinsic(api, proofType, params);
+  const extrinsic = createSubmitProofExtrinsic(
+    api,
+    proofType,
+    params,
+    domainId,
+  );
   return extrinsic.toHex();
 };
 

--- a/src/api/optimisticVerify/index.ts
+++ b/src/api/optimisticVerify/index.ts
@@ -62,6 +62,7 @@ const buildTransaction = (
       api,
       proofOptions.proofType,
       formattedProofData,
+      input.domainId,
     );
   }
 

--- a/src/api/verify/index.ts
+++ b/src/api/verify/index.ts
@@ -46,6 +46,7 @@ export const verify = async (
         api,
         options.proofOptions.proofType,
         formattedProofData,
+        input.domainId,
       );
     } else if ('extrinsic' in input && input.extrinsic) {
       transaction = input.extrinsic;

--- a/src/api/verify/types.ts
+++ b/src/api/verify/types.ts
@@ -2,5 +2,9 @@ import { SubmittableExtrinsic } from '@polkadot/api/types';
 import { ProofData } from '../../types';
 
 export type VerifyInput =
-  | { proofData: ProofData; extrinsic?: never }
-  | { extrinsic: SubmittableExtrinsic<'promise'>; proofData?: never };
+  | { proofData: ProofData; domainId?: number | null; extrinsic?: never }
+  | {
+      extrinsic: SubmittableExtrinsic<'promise'>;
+      domainId?: number | null;
+      proofData?: never;
+    };

--- a/src/session/managers/extrinsic/index.ts
+++ b/src/session/managers/extrinsic/index.ts
@@ -30,11 +30,13 @@ export class ExtrinsicManager {
   async createSubmitProofExtrinsic(
     proofType: ProofType,
     params: FormattedProofData,
+    domainId?: number | null,
   ): Promise<SubmittableExtrinsic<'promise'>> {
     return createSubmitProofExtrinsic(
       this.connectionManager.api,
       proofType,
       params,
+      domainId,
     );
   }
 
@@ -49,8 +51,14 @@ export class ExtrinsicManager {
   async createExtrinsicHex(
     proofType: ProofType,
     params: FormattedProofData,
+    domainId?: number | null,
   ): Promise<string> {
-    return createExtrinsicHex(this.connectionManager.api, proofType, params);
+    return createExtrinsicHex(
+      this.connectionManager.api,
+      proofType,
+      params,
+      domainId,
+    );
   }
 
   /**


### PR DESCRIPTION
Jira ticket: [[WEB3-1379] zkVerifyJS: Allow domain ID parameter for createSubmitProofExtrinsic](https://horizenlabs.atlassian.net/browse/WEB3-1379)

This PR introduces domain ID support for proof verification.

## Changes
- Added optional `domainId` parameter to proof verification methods
- Updated `createSubmitProofExtrinsic` and `createExtrinsicHex` to support domain ID
- Updated documentation with new multi-account examples and API reference
- Updated test coverage for domain ID 

## Features
- **Domain ID Support**: Users can now specify a domain ID when verifying proofs, enabling better organization and categorization of proofs
