### PR TITLE
chore: update repository and contact information

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,15 +2,15 @@
   "name": "zkverifyjs",
   "version": "0.14.0",
   "description": "Submit proofs to zkVerify and query proof state with ease using our npm package.",
-  "author": "Horizen Labs <research@horizenlabs.io>",
+  "author": "zkVerify <web3-platform@zkverify.io>",
   "license": "GPL-3.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/HorizenLabs/zkverifyjs.git"
+    "url": "https://github.com/zkVerify/zkverifyjs.git"
   },
   "bugs": {
-    "url": "https://github.com/HorizenLabs/zkverifyjs/issues",
-    "email": "support@horizenlabs.io"
+    "url": "https://github.com/zkVerify/zkverifyjs/issues",
+    "email": "web3-platform@zkverify.io"
   },
   "main": "dist/commonjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
Jira ticket: [[WEB3-1547] ZKVerifyJS - Update author and repository URL in package.json](https://horizenlabs.atlassian.net/browse/WEB3-1547)

This PR is part of the migration process of the zkverifyjs repository from Horizen Labs to the zkVerify organization. The changes ensure all repository metadata and contact information are properly updated to reflect the new ownership.

## Changes
- Updated author information from Horizen Labs to zkVerify
- Updated repository URL to point to the new zkVerify organization
- Updated bug report URL and contact email to use zkVerify domains
- Maintained all existing functionality and package versioning

## Features
- No new features added

This change is purely administrative and does not affect the package's functionality or API. Users can continue using the package as before, with the only difference being the updated repository location and contact information.